### PR TITLE
Add support for PEP 525-style garbage collection hooks

### DIFF
--- a/async_generator/__init__.py
+++ b/async_generator/__init__.py
@@ -5,6 +5,8 @@ from ._impl import (
     yield_from_,
     isasyncgen,
     isasyncgenfunction,
+    get_asyncgen_hooks,
+    set_asyncgen_hooks,
 )
 from ._util import aclosing, asynccontextmanager
 
@@ -16,4 +18,6 @@ __all__ = [
     "isasyncgen",
     "isasyncgenfunction",
     "asynccontextmanager",
+    "get_asyncgen_hooks",
+    "set_asyncgen_hooks",
 ]

--- a/async_generator/_impl.py
+++ b/async_generator/_impl.py
@@ -277,6 +277,7 @@ class AsyncGenerator:
         self.ag_running = False
         self._finalizer = None
         self._closed = False
+        self._hooks_inited = False
 
     # On python 3.5.0 and 3.5.1, __aiter__ must be awaitable.
     # Starting in 3.5.2, it should not be awaitable, and if it is, then it
@@ -325,8 +326,8 @@ class AsyncGenerator:
         return self._do_it(self._it.throw, type, value, traceback)
 
     def _do_it(self, start_fn, *args):
-        coro_state = getcoroutinestate(self._coroutine)
-        if coro_state is CORO_CREATED:
+        if not self._hooks_inited:
+            self._hooks_inited = True
             (firstiter, self._finalizer) = get_asyncgen_hooks()
             if firstiter is not None:
                 firstiter(self)
@@ -357,6 +358,9 @@ class AsyncGenerator:
         state = getcoroutinestate(self._coroutine)
         if state is CORO_CLOSED or self._closed:
             return
+        # Make sure that even if we raise "async_generator ignored
+        # GeneratorExit", and thus fail to exhaust the coroutine,
+        # __del__ doesn't complain again.
         self._closed = True
         if state is CORO_CREATED:
             # Make sure that aclose() on an unstarted generator returns

--- a/async_generator/_impl.py
+++ b/async_generator/_impl.py
@@ -271,6 +271,23 @@ except ImportError:
 
 
 class AsyncGenerator:
+    # https://bitbucket.org/pypy/pypy/issues/2786:
+    # PyPy implements 'await' in a way that requires the frame object
+    # used to execute a coroutine to keep a weakref to that coroutine.
+    # During a GC pass, weakrefs to all doomed objects are broken
+    # before any of the doomed objects' finalizers are invoked.
+    # If an AsyncGenerator is unreachable, its _coroutine probably
+    # is too, and the weakref from ag._coroutine.cr_frame to
+    # ag._coroutine will be broken before ag.__del__ can do its
+    # one-turn close attempt or can schedule a full aclose() using
+    # the registered finalization hook. It doesn't look like the
+    # underlying issue is likely to be fully fixed anytime soon,
+    # so we work around it by preventing an AsyncGenerator and
+    # its _coroutine from being considered newly unreachable at
+    # the same time if the AsyncGenerator's finalizer might want
+    # to iterate the coroutine some more.
+    _pypy_issue2786_workaround = set()
+
     def __init__(self, coroutine):
         self._coroutine = coroutine
         self._it = coroutine.__await__()
@@ -331,6 +348,8 @@ class AsyncGenerator:
             (firstiter, self._finalizer) = get_asyncgen_hooks()
             if firstiter is not None:
                 firstiter(self)
+            if sys.implementation.name == "pypy":
+                self._pypy_issue2786_workaround.add(self._coroutine)
 
         # On CPython 3.5.2 (but not 3.5.0), coroutines get cranky if you try
         # to iterate them after they're exhausted. Generators OTOH just raise
@@ -345,6 +364,9 @@ class AsyncGenerator:
             try:
                 self.ag_running = True
                 return await ANextIter(self._it, start_fn, *args)
+            except StopAsyncIteration:
+                self._pypy_issue2786_workaround.discard(self._coroutine)
+                raise
             finally:
                 self.ag_running = False
 
@@ -370,27 +392,19 @@ class AsyncGenerator:
         try:
             await self.athrow(GeneratorExit)
         except (GeneratorExit, StopAsyncIteration):
-            pass
+            self._pypy_issue2786_workaround.discard(self._coroutine)
         else:
             raise RuntimeError("async_generator ignored GeneratorExit")
 
     def __del__(self):
+        self._pypy_issue2786_workaround.discard(self._coroutine)
         if getcoroutinestate(self._coroutine) is CORO_CREATED:
             # Never started, nothing to clean up, just suppress the "coroutine
             # never awaited" message.
             self._coroutine.close()
         if getcoroutinestate(self._coroutine
                              ) is CORO_SUSPENDED and not self._closed:
-            if sys.implementation.name == "pypy":
-                # pypy segfaults if we resume the coroutine from our __del__
-                # and it executes any more 'await' statements, so we use the
-                # old async_generator behavior of "don't even try to finalize
-                # correctly". https://bitbucket.org/pypy/pypy/issues/2786/
-                raise RuntimeError(
-                    "partially-exhausted async_generator {!r} garbage collected"
-                    .format(self.ag_code.co_name)
-                )
-            elif self._finalizer is not None:
+            if self._finalizer is not None:
                 self._finalizer(self)
             else:
                 # Mimic the behavior of native generators on GC with no finalizer:

--- a/async_generator/_tests/test_async_generator.py
+++ b/async_generator/_tests/test_async_generator.py
@@ -970,7 +970,8 @@ async def test_gc_hooks_behavior(local_asyncgen_hooks):
     del iterA
     # Do multiple GC passes since we're deliberately shielding the
     # coroutine objects from the first pass due to PyPy issue 2786.
-    for _ in range(4): gc.collect()
+    for _ in range(4):
+        gc.collect()
     assert refA() is None
     assert events == [
         "yield 2 A", "after yield 2 A", "mock_sleep A", "yield 3 A",
@@ -985,9 +986,11 @@ async def test_gc_hooks_behavior(local_asyncgen_hooks):
     await iterC.__anext__()
     idB, idC = id(iterB), id(iterC)
     del iterB
-    for _ in range(4): gc.collect()
+    for _ in range(4):
+        gc.collect()
     del iterC
-    for _ in range(4): gc.collect()
+    for _ in range(4):
+        gc.collect()
     assert events == [
         "yield 2 C", "yield 2 B", "after yield 2 C", "mock_sleep C",
         "yield 3 C", "finalizer B", "finalizer C"
@@ -1002,7 +1005,8 @@ async def test_gc_hooks_behavior(local_asyncgen_hooks):
     await to_finalize[1].aclose()
     events.append("after aclose both")
     del to_finalize[:]
-    for _ in range(4): gc.collect()
+    for _ in range(4):
+        gc.collect()
     assert refB() is None and refC() is None
 
     assert events == [

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -123,7 +123,11 @@ You can use ``async_generator.set_asyncgen_hooks()`` exactly
 like you would use ``sys.set_asyncgen_hooks()`` with native
 generators. On Python 3.6+, the former is an alias for the latter,
 so libraries that use the native mechanism should work seamlessly
-with ``@async_generator`` functions.
+with ``@async_generator`` functions. On Python 3.5, where there is
+no ``sys.set_asyncgen_hooks()``, most libraries probably *won't* know
+about ``async_generator.set_asyncgen_hooks()``, so you'll need
+to exercise more care with explicit cleanup, or install appropriate
+hooks yourself.
 
 While finishing cleanup of an async generator is better than dropping
 it on the floor at the first ``await``, it's still not a perfect solution;

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -107,17 +107,38 @@ Semantics
 
 This library generally tries hard to match the semantics of Python
 3.6's native async generators in every detail (`PEP 525
-<https://www.python.org/dev/peps/pep-0525/>`__), except that it adds
-``yield from`` support, and it doesn't currently support the
-``sys.{get,set}_asyncgen_hooks`` garbage collection API. There are two
-main reasons for this: (a) it doesn't exist on Python 3.5, and (b)
-even on 3.6, only built-in generators are supposed to use that API,
-and that's not us. In any case, you probably shouldn't be relying on
-garbage collection for async generators – see `this discussion
+<https://www.python.org/dev/peps/pep-0525/>`__), with additional
+support for ``yield from`` and for returning non-None values from
+an async generator (under the theory that these may well be added
+to native async generators one day).
+
+
+Garbage collection hooks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This library fully supports the native async generator
+`finalization semantics <https://www.python.org/dev/peps/pep-0525/#finalization>`__,
+including the per-thread ``firstiter`` and ``finalizer`` hooks.
+You can use ``async_generator.set_asyncgen_hooks()`` exactly
+like you would use ``sys.set_asyncgen_hooks()`` with native
+generators. On Python 3.6+, the former is an alias for the latter,
+so libraries that use the native mechanism should work seamlessly
+with ``@async_generator`` functions.
+
+While finishing cleanup of an async generator is better than dropping
+it on the floor at the first ``await``, it's still not a perfect solution;
+in addition to the unpredictability of GC timing, the ``finalizer`` hook
+has no practical way to determine the context in which the generator was
+being iterated, so an exception thrown from the generator during ``aclose()``
+must either crash the program or get discarded. It's much better to close
+your generators explicitly when you're done with them, perhaps using the
+:ref:`aclosing context manager <contextmanagers>`. See `this discussion
 <https://vorpus.org/blog/some-thoughts-on-asynchronous-api-design-in-a-post-asyncawait-world/#cleanup-in-generators-and-async-generators>`__
 and `PEP 533 <https://www.python.org/dev/peps/pep-0533/>`__ for more
 details.
 
+
+.. _contextmanagers:
 
 Context managers
 ----------------
@@ -135,7 +156,7 @@ module, but does ``await obj.aclose()`` instead of
        async for json_obj in agen:
            ...
 
-Or if you want to write your own async context managers, we got you
+Or if you want to write your own async context managers, we've got you
 covered:
 
 .. function:: asynccontextmanager

--- a/newsfragments/15.feature.rst
+++ b/newsfragments/15.feature.rst
@@ -1,0 +1,5 @@
+Add support for PEP 525-style finalization hooks via ``set_asyncgen_hooks()``
+and ``get_asyncgen_hooks()`` functions, which mimic the behavior of the ones
+in ``sys`` if we're running on a Python version that doesn't have them natively.
+``@async_generator`` generators behave the same way as native ones with respect
+to these hooks.


### PR DESCRIPTION
Add `async_generator.get_asyncgen_hooks()` and `async_generator.set_asyncgen_hooks()`, and use them under the same circumstances the equivalents in `sys` would be used for native generators. On 3.6+, the `async_generator` names refer to the same functions as the `sys` names, so there's only one set of hooks, and frameworks that use `sys.set_asyncgen_hooks()` should work seamlessly with `async_generator` functions as well.

There's an issue with GC ordering or something in pypy, which causes the new logic to make the interpreter segfault under some circumstances, so keep the old logic (which complains if any async_generator is GC'ed before its execution has completed) if we detect that we're running under pypy. The bug has been reported upstream: https://bitbucket.org/pypy/pypy/issues/2786/