### PR TITLE
Make yield_ and yield_from_ interoperate with native async generators again

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -28,6 +28,8 @@ Basically:
 That's it!
 
 
+.. _yieldfrom:
+
 Yield from
 ~~~~~~~~~~
 
@@ -47,9 +49,12 @@ But we do::
     async def wrap_load_json_lines(stream_reader):
         await yield_from_(load_json_lines(stream_reader))
 
-You can only use ``yield_from_`` inside an ``@async_generator``
-function, BUT the thing you PASS to ``yield_from_`` can be any kind of
-async iterator, including native async generators.
+You can use ``yield_from_`` inside a native async generator or an
+``@async_generator`` function, and the argument can be any async
+iterable. Remember that a native async generator is only created
+when an ``async def`` block contains at least one ``yield``
+statement; if you only ``yield_from_`` and never ``yield``,
+use the ``@async_generator`` decorator.
 
 Our ``yield_from_`` fully supports the classic ``yield from``
 semantics, including forwarding ``asend`` and ``athrow`` calls into

--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,0 +1,1 @@
+On CPython 3.6+, restore the ability for a native async generator to ``yield_from_`` an ``@async_generator`` function and vice versa, by using the same value-wrapper type that Python uses internally if we're running on a Python version that supports native async generators. The new approach should be much less prone to refcounting bugs or to issues on different architectures.


### PR DESCRIPTION
Instead of trying to explicitly construct AsyncGenValueWrapper objects, trick the interpreter into doing the wrapping and unwrapping for us. There's still some ctypes hackery involved, but it's much less finicky: just changing the type of an async generator object.