### PR TITLE
Implement AsyncGenerator type annotation

### DIFF
--- a/async_generator/__init__.py
+++ b/async_generator/__init__.py
@@ -9,6 +9,7 @@ from ._impl import (
     set_asyncgen_hooks,
 )
 from ._util import aclosing, asynccontextmanager
+from . import typing
 
 __all__ = [
     "async_generator",
@@ -20,4 +21,5 @@ __all__ = [
     "asynccontextmanager",
     "get_asyncgen_hooks",
     "set_asyncgen_hooks",
+    "typing",
 ]

--- a/async_generator/typing.py
+++ b/async_generator/typing.py
@@ -1,0 +1,16 @@
+try:
+    from typing import AsyncGenerator
+except ImportError:
+    from typing import TypeVar, AsyncIterator, Generic
+    from . import _impl
+
+    T_co = TypeVar('T_co', covariant=True)
+    T_contra = TypeVar('T_contra', contravariant=True)
+
+    class AsyncGenerator(AsyncIterator[T_co], Generic[T_co, T_contra],
+                         extra=_impl.AsyncGenerator):
+        __slots__ = ()
+
+__all__ = [
+    'AsyncGenerator'
+]

--- a/async_generator/typing.py
+++ b/async_generator/typing.py
@@ -11,6 +11,4 @@ except ImportError:
                          extra=_impl.AsyncGenerator):
         __slots__ = ()
 
-__all__ = [
-    'AsyncGenerator'
-]
+__all__ = ['AsyncGenerator']


### PR DESCRIPTION
`typing.AsyncGenerator` was added in 3.5.4 https://github.com/python/cpython/commit/e9ed560fcec8d2d1f9705e93049cdb3790d40838

debian stretch python3 has version 3.5.3. https://packages.debian.org/stretch/python3

Implementation itself is based on original cpython commit above