### PR TITLE
Fix @asynccontextmanager doesn't work well with async generators

### DIFF
--- a/async_generator/_util.py
+++ b/async_generator/_util.py
@@ -51,9 +51,10 @@ class _AsyncGeneratorContextManager:
                 assert value is not None
                 try:
                     await self._agen.athrow(type, value, traceback)
-                    raise RuntimeError(
-                        "async generator didn't stop after athrow()"
-                    )
+                    if sys.version_info[:2] >= (3, 8) or not isinstance(value, GeneratorExit):
+                        raise RuntimeError(
+                            "async generator didn't stop after athrow()"
+                        )
                 except StopAsyncIteration as exc:
                     # Suppress StopIteration *unless* it's the same exception
                     # that was passed to throw(). This prevents a

--- a/async_generator/_util.py
+++ b/async_generator/_util.py
@@ -51,7 +51,7 @@ class _AsyncGeneratorContextManager:
                 assert value is not None
                 try:
                     await self._agen.athrow(type, value, traceback)
-                    if sys.version_info[:2] >= (3, 8) or not isinstance(value, GeneratorExit):
+                    if sys.version_info[:3] >= (3, 7, 9) or not isinstance(value, GeneratorExit):
                         raise RuntimeError(
                             "async generator didn't stop after athrow()"
                         )


### PR DESCRIPTION
Workaround for https://bugs.python.org/issue33786 that wasn't backported until python 3.7.9: https://github.com/python/cpython/commits/13c94747c74437e594b7fc242ff7da668e81887c.